### PR TITLE
Added BananaPI compatibility stuff.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+
 #*********************************************************************
 # This is the makefile for the ArduiPi OLED library driver
 #
@@ -10,7 +11,24 @@
 # 07/26/2013	Charles-Henri Hallard
 #							modified name for generic library using different OLED type
 #
+# 08/26/2015	Lorenzo Delana (lorenzo.delana@gmail.com)
+#							added bananapi specific CCFLAGS and conditional macro BANANPI
+#
 # *********************************************************************
+
+# Makefile itself dir
+ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
+# hw platform as from autogen.sh choose
+HWPLAT:=$(shell cat $(ROOT_DIR)/hwplatform)
+
+# sets CCFLAGS hw platform dependant
+ifeq ($(HWPLAT),BananaPI)
+	CCFLAGS=-Wall -Ofast -mfpu=vfpv4 -mfloat-abi=hard -march=armv7 -mtune=cortex-a7 -DBANANAPI
+else # fallback to raspberry
+	# The recommended compiler flags for the Raspberry Pi
+	CCFLAGS=-Ofast -mfpu=vfp -mfloat-abi=hard -march=armv6zk -mtune=arm1176jzf-s
+endif
 
 # Where you want it installed when you do 'make install'
 PREFIX=/usr/local
@@ -23,12 +41,13 @@ LIB=libArduiPi_OLED
 # shared library name
 LIBNAME=$(LIB).so.1.0
 
-# The recommended compiler flags for the Raspberry Pi
-CCFLAGS=-Ofast -mfpu=vfp -mfloat-abi=hard -march=armv6zk -mtune=arm1176jzf-s
-
 # make all
 # reinstall the library after each recompilation
 all: ArduiPi_OLED install
+
+# setup cflags
+cflagsset:
+	echo $(CCFLAGS)
 
 # Make the library
 ArduiPi_OLED: ArduiPi_OLED.o Adafruit_GFX.o bcm2835.o 

--- a/README.bananapi.md
+++ b/README.bananapi.md
@@ -1,0 +1,3 @@
+# Bananapi
+
+Banana pi version requires `autogen.sh` before `make`.

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,35 @@
+# autogen.sh
+#----------------------------------------------------------
+# Copyright(C) 2015 Lorenzo Delana, License under MIT
+#
+#   https://github.com/devel0/ArduiPi_SSD1306
+#
+# Summary : adapt code to be bananapi compatible, in short
+#           - set i2c-2 device port
+#           - adjust CCFLAGS for the library and examples
+
+BASEDIR=$(dirname $0)
+
+echo "Specify your platform:"
+echo "  1. RaspberryPI"
+echo "  2. BananaPI"
+
+read -n 1 c
+echo
+
+if [ "$c" == "1" ]; then
+	echo "Setting for RaspberryPI"
+	HW="RaspberryPI"
+elif [ "$c" == "2" ]; then
+	echo "Setting for BananaPI"
+	HW="BananaPI"
+else
+	echo "Invalid argument given."
+	HW="RaspberryPI" # fallback to raspi
+	exit
+fi
+
+echo $HW > $BASEDIR/hwplatform
+
+echo "run make to build"
+

--- a/bcm2835.c
+++ b/bcm2835.c
@@ -16,6 +16,9 @@
 //              Added function to determine PI revision board
 //							Added function to set SPI speed (instead of divider for easier look in code)
 // 06/29/2013   Incorporated latest version of bcm2825.h done by Mike McCauley
+// 
+// 08/26/2015	Lorenzo Delana (lorenzo.delana@gmail.com)
+//		Use of i2c-2 if BANANAPI macro enabled
 
 
 #include <stdio.h>
@@ -813,7 +816,11 @@ int bcm2835_i2c_begin(void)
 {
 	int fd ;
 
+#if BANANAPI
+	if ((fd = open ("/dev/i2c-2", O_RDWR)) < 0)
+#else
 	if ((fd = open (bcm2835_get_pi_version() == 1 ? "/dev/i2c-0":"/dev/i2c-1" , O_RDWR)) < 0)
+#endif
 		return fd;
 		
 	// Set i2c descriptor

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -7,13 +7,26 @@
 #							the command line (no more #define on compilation needed)
 #							ArduiPi project documentation http://hallard.me/arduipi
 #
+# 08/26/2015    Lorenzo Delana (lorenzo.delana@gmail.com)
+#                                                       added bananapi specific CCFLAGS and conditional macro BANANPI
+#
 # *********************************************************************
 
-prefix := /usr/local
+# Makefile itself dir
+ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
-# The recommended compiler flags for the Raspberry Pi
-CCFLAGS=-Ofast -mfpu=vfp -mfloat-abi=hard -march=armv6zk -mtune=arm1176jzf-s
-#CCFLAGS=
+# hw platform as from autogen.sh choose
+HWPLAT:=$(shell cat $(ROOT_DIR)/../hwplatform)
+
+# sets CCFLAGS hw platform dependant
+ifeq ($(HWPLAT),BananaPI)
+        CCFLAGS=-Wall -Ofast -mfpu=vfpv4 -mfloat-abi=hard -march=armv7 -mtune=cortex-a7 -DBANANAPI
+else # fallback to raspberry
+        # The recommended compiler flags for the Raspberry Pi
+        CCFLAGS=-Ofast -mfpu=vfp -mfloat-abi=hard -march=armv6zk -mtune=arm1176jzf-s
+endif
+
+prefix := /usr/local
 
 # define all programs
 PROGRAMS = oled_demo teleinfo-oled

--- a/hwplatform
+++ b/hwplatform
@@ -1,0 +1,1 @@
+RaspberryPI


### PR DESCRIPTION
Hi hallard,
thanks for your nice library, I successfully used with my bananapi and oled ssd1306 i2c-bus mode withing the changes this pull request.

Follow the commit changes in short : 
- added an autogen.sh file to let the use choose between Raspi or Banana platform
- adjusted library and examples Makefile to tune the CCFLAGS accordingly the hwplatform and sets a macro for bananapi
- use of the bananapi macro from the bcm2835.c file to use the i2c-2 bus instead the {0,1} availables for raspberry