### PR TITLE
Fix compile issue when including outside of main

### DIFF
--- a/Adafruit_GFX.h
+++ b/Adafruit_GFX.h
@@ -32,9 +32,9 @@ class Adafruit_GFX {
   //Adafruit_GFX();
   // i have no idea why we have to formally call the constructor. kinda sux
   void constructor(int16_t w, int16_t h);
-
+  virtual ~Adafruit_GFX(){};
   // this must be defined by the subclass
-  virtual void drawPixel(int16_t x, int16_t y, uint16_t color);
+  virtual void drawPixel(int16_t x, int16_t y, uint16_t color) = 0;
   virtual void invertDisplay(boolean i);
 	
 	// the printf function


### PR DESCRIPTION
Seems theres compile issues when including the library outside of the main cpp file, see here:
See http://forum.pjrc.com/threads/10-Adafruit-PCD8544-LCD-library?p=87&viewfull=1#post87

The same change had been applied to the original Adafruit library, see here:
https://github.com/adafruit/Adafruit-GFX-Library/pull/7