### PR TITLE
support Quartz64 Model B on I2C-3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ HWPLAT:=$(shell cat $(ROOT_DIR)/hwplatform)
 # sets CCFLAGS hw platform dependant
 ifeq ($(HWPLAT),BananaPI)
 	CCFLAGS=-Wall -Ofast -mfpu=vfpv4 -mfloat-abi=hard -march=armv7 -mtune=cortex-a7 -DBANANAPI
+else ifeq ($(HWPLAT),Quartz64B)
+	CCFLAGS=-Wall -Ofast -DQUARTZ64B
 else # fallback to raspberry
 	# The recommended compiler flags for the Raspberry Pi
 	CCFLAGS=-Ofast -mfpu=vfp -mfloat-abi=hard -march=armv6zk -mtune=arm1176jzf-s

--- a/README.quartz64b.md
+++ b/README.quartz64b.md
@@ -1,0 +1,3 @@
+# Quartz 64 Model B
+
+Quartz64 version requires `autogen.sh` before `make`, and only supports I2C-3.

--- a/autogen.sh
+++ b/autogen.sh
@@ -15,6 +15,7 @@ BASEDIR=`realpath $BD`
 echo "Specify your platform:"
 echo "  1. RaspberryPI"
 echo "  2. BananaPI"
+echo "  3. Quartz64 Model B"
 
 read -n 1 c
 echo
@@ -25,6 +26,9 @@ if [ "$c" == "1" ]; then
 elif [ "$c" == "2" ]; then
 	echo "Setting for BananaPI"
 	HW="BananaPI"
+elif [ "$c" == "3" ]; then
+	echo "Setting for Quartz64 Model B"
+	HW="Quartz64B"
 else
 	echo "Invalid argument given."
 	HW="RaspberryPI" # fallback to raspi

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -21,6 +21,8 @@ HWPLAT:=$(shell cat $(ROOT_DIR)/../hwplatform)
 # sets CCFLAGS hw platform dependant
 ifeq ($(HWPLAT),BananaPI)
         CCFLAGS=-Wall -Ofast -mfpu=vfpv4 -mfloat-abi=hard -march=armv7 -mtune=cortex-a7 -DBANANAPI
+else ifeq ($(HWPLAT),Quartz64B)
+	CCFLAGS=-Wall -Ofast -DQUARTZ64B
 else # fallback to raspberry
         # The recommended compiler flags for the Raspberry Pi
         CCFLAGS=-Ofast -mfpu=vfp -mfloat-abi=hard -march=armv6zk -mtune=arm1176jzf-s


### PR DESCRIPTION
I recently started running MMDVMHost on a [Quartz64 Model B][quartz64], and have modified this source to support OLED modules on I2C3, which is the I2C bus exposed by this board on the same pins that most MMDVM Pi hats use. This is a hackjob -- I basically pointed it at `/dev/i2c-3` and `#ifdef`'d out the Broadcom-specific parts. SPI doesn't work at all. That said, it works great!

 [quartz64]: https://www.pine64.org/quartz64b/

Since this is such a hackjob, you may decide not to merge. That's fine! I thought I would create a PR at least so if anybody else goes down this road, they know where to look.