### PR TITLE
Modern adaptations: Orange Pi Zero 3 support; fix libi2c-dev compatibility on Raspberry Pi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,20 @@
 #*********************************************************************
 # This is the makefile for the ArduiPi OLED library driver
 #
-#	02/18/2013 	Charles-Henri Hallard (http://hallard.me)
-#							Modified for compiling and use on Raspberry ArduiPi Board
-#							LCD size and connection are now passed as arguments on 
-#							the command line (no more #define on compilation needed)
-#							ArduiPi project documentation http://hallard.me/arduipi
+# 02/18/2013    Charles-Henri Hallard (http://hallard.me)
+#               Modified for compiling and use on Raspberry ArduiPi Board
+#               LCD size and connection are now passed as arguments on 
+#               the command line (no more #define on compilation needed)
+#               ArduiPi project documentation http://hallard.me/arduipi
 # 
-# 07/26/2013	Charles-Henri Hallard
-#							modified name for generic library using different OLED type
+# 07/26/2013    Charles-Henri Hallard
+#               modified name for generic library using different OLED type
 #
-# 08/26/2015	Lorenzo Delana (lorenzo.delana@gmail.com)
-#							added bananapi specific CCFLAGS and conditional macro BANANPI
+# 08/26/2015    Lorenzo Delana (lorenzo.delana@gmail.com)
+#               added bananapi specific CCFLAGS and conditional macro BANANPI
+#
+# 09/01/2025    Alexander Mokrov (ur6lkw@olympy.org.ua)
+#               Orange Pi Zero 3 support if OPIZ3 macro enabled
 #
 # *********************************************************************
 
@@ -25,6 +28,8 @@ HWPLAT:=$(shell cat $(ROOT_DIR)/hwplatform)
 # sets CCFLAGS hw platform dependant
 ifeq ($(HWPLAT),BananaPI)
 	CCFLAGS=-Wall -Ofast -mfpu=vfpv4 -mfloat-abi=hard -march=armv7 -mtune=cortex-a7 -DBANANAPI
+else ifeq ($(HWPLAT),OPIZ3)
+	CCFLAGS=-Ofast -march=native -DOPIZ3
 else # fallback to raspberry
 	# The recommended compiler flags for the Raspberry Pi
 	CCFLAGS=-Ofast -mfpu=vfp -mfloat-abi=hard -march=armv6zk -mtune=arm1176jzf-s

--- a/autogen.sh
+++ b/autogen.sh
@@ -8,6 +8,9 @@
 # Summary : adapt code to be bananapi compatible, in short
 #           - set i2c-2 device port
 #           - adjust CCFLAGS for the library and examples
+#
+# UR6LKW 2025-09-01 :
+#   - Orange PI Zero 3 support (/dev/i2c-3 port, CFLAGS)
 
 BD=`dirname $0`
 BASEDIR=`realpath $BD`
@@ -15,6 +18,7 @@ BASEDIR=`realpath $BD`
 echo "Specify your platform:"
 echo "  1. RaspberryPI"
 echo "  2. BananaPI"
+echo "  3. OrangePI Zero3"
 
 read -n 1 c
 echo
@@ -25,6 +29,9 @@ if [ "$c" == "1" ]; then
 elif [ "$c" == "2" ]; then
 	echo "Setting for BananaPI"
 	HW="BananaPI"
+elif [ "$c" == "3" ]; then
+	echo "Setting for OrangePI Zero3"
+	HW="OPIZ3"
 else
 	echo "Invalid argument given."
 	HW="RaspberryPI" # fallback to raspi

--- a/bcm2835.c
+++ b/bcm2835.c
@@ -30,6 +30,7 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <linux/i2c-dev.h>
+#include <i2c/smbus.h>
 
 #include <errno.h>
 #include <sys/mman.h>

--- a/bcm2835.c
+++ b/bcm2835.c
@@ -7,18 +7,22 @@
 // Author: Mike McCauley
 // Copyright (C) 2011-2013 Mike McCauley
 // $Id: bcm2835.c,v 1.10 2013/03/18 05:57:36 mikem Exp mikem $
-// 
+//
 // 03/17/2013 : Charles-Henri Hallard (http://hallard.me)
 //              Modified Adding some fonctionnalities
-//							Added millis() function
+//              Added millis() function
 //              Added option to use custom Chip Select Pin PI GPIO instead of only CE0 CE1
 //              Done a hack to use CE1 by software as custom CS pin because HW does not work
 //              Added function to determine PI revision board
-//							Added function to set SPI speed (instead of divider for easier look in code)
+//              Added function to set SPI speed (instead of divider for easier look in code)
+//
 // 06/29/2013   Incorporated latest version of bcm2825.h done by Mike McCauley
-// 
-// 08/26/2015	Lorenzo Delana (lorenzo.delana@gmail.com)
-//		Use of i2c-2 if BANANAPI macro enabled
+//
+// 08/26/2015   Lorenzo Delana (lorenzo.delana@gmail.com)
+//              Use of i2c-2 if BANANAPI macro enabled
+//
+// 09/01/2025   Alexander Mokrov (ur6lkw@olympy.org.ua)
+//              Orange Pi Zero 3 support if OPIZ3 macro enabled
 
 
 #include <stdio.h>
@@ -817,7 +821,11 @@ int bcm2835_i2c_begin(void)
 	int fd ;
 
 #if BANANAPI
+#pragma message "Using Banana Pi config - /dev/i2c-2"
 	if ((fd = open ("/dev/i2c-2", O_RDWR)) < 0)
+#elif OPIZ3
+#pragma message "Using Orange Pi Zero 3 config - /dev/i2c-3"
+	if ((fd = open ("/dev/i2c-3", O_RDWR)) < 0)
 #else
 	if ((fd = open (bcm2835_get_pi_version() == 1 ? "/dev/i2c-0":"/dev/i2c-1" , O_RDWR)) < 0)
 #endif


### PR DESCRIPTION
Modern adaptations to be used in WPSD.
- Added Orange Pi Zero 3 support. Use 3rd option in ./autogen.sh to build.
- Fixed building error on Raspberry Pi.